### PR TITLE
Upgrade @pinecone-database/pinecone v2 → v8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
-        "@pinecone-database/pinecone": "^2.0.0",
+        "@pinecone-database/pinecone": "^8.0.0",
         "@radix-ui/react-alert-dialog": "^1.0.5",
         "console-table-printer": "^2.11.1",
         "cross-fetch": "^3.1.6",
@@ -56,9 +56,12 @@
         "tsconfig-paths": "^4.2.0",
         "tsup": "^8.5.1",
         "tsx": "^4.23.0",
-        "typescript": "^5.0.2",
+        "typescript": "^5.2.0",
         "vite": "^8.1.3",
         "vitest": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1638,18 +1641,12 @@
       }
     },
     "node_modules/@pinecone-database/pinecone": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@pinecone-database/pinecone/-/pinecone-2.2.2.tgz",
-      "integrity": "sha512-gbe/4SowHc64pHIm0kBdgY9hVdzsQnnnpcWviwYMB33gOmsL8brvE8fUSpl1dLDvdyXzKcQkzdBsjCDlqgpdMA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@pinecone-database/pinecone/-/pinecone-8.0.0.tgz",
+      "integrity": "sha512-dItFqLdis2Pd5lC67aKn8HhvXajzlOz4+0RyK1CRcZMdSwG8YxUCBtH4yXPC8/6uLxfr2dvMWnRFuKgtPwwajQ==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@sinclair/typebox": "^0.29.0",
-        "ajv": "^8.12.0",
-        "cross-fetch": "^3.1.5",
-        "encoding": "^0.1.13"
-      },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -2680,12 +2677,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@sinclair/typebox": {
-      "version": "0.29.6",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.29.6.tgz",
-      "integrity": "sha512-aX5IFYWlMa7tQ8xZr3b2gtVReCvg7f3LEhjir/JAjX2bJCMVJA5tIPv30wTD4KDfcwMd7DDYY3hFDeGmOgtrZQ==",
-      "license": "MIT"
-    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -3413,22 +3404,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-regex": {
@@ -4688,6 +4663,8 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -5524,6 +5501,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -5583,22 +5561,6 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -6293,6 +6255,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -6963,12 +6926,6 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -8885,6 +8842,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -31,9 +31,12 @@
   ],
   "author": "Roie Schwaber-Cohen",
   "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
   "dependencies": {
     "@huggingface/transformers": "^4.2.0",
-    "@pinecone-database/pinecone": "^2.0.0",
+    "@pinecone-database/pinecone": "^8.0.0",
     "@radix-ui/react-alert-dialog": "^1.0.5",
     "console-table-printer": "^2.11.1",
     "cross-fetch": "^3.1.6",
@@ -79,7 +82,7 @@
     "tsconfig-paths": "^4.2.0",
     "tsup": "^8.5.1",
     "tsx": "^4.23.0",
-    "typescript": "^5.0.2",
+    "typescript": "^5.2.0",
     "vite": "^8.1.3",
     "vitest": "^3.2.7"
   }

--- a/server/deleteImage.ts
+++ b/server/deleteImage.ts
@@ -27,7 +27,10 @@ const getPineconeId = async (imagePath: string) => {
 
 const deleteImage = async (imagePath: string) => {
   const pineconeId = await getPineconeId(imagePath);
-  await getIndex().namespace("default").deleteOne(pineconeId);
+  if (!pineconeId) {
+    throw new Error(`No indexed vector found for image: ${imagePath}`);
+  }
+  await getIndex().namespace("default").deleteOne({ id: pineconeId });
   // Append _deleted to the image path for demo purposes
   await fs.rename(imagePath, `${imagePath}_deleted`);
 };

--- a/server/embeddings.ts
+++ b/server/embeddings.ts
@@ -7,6 +7,11 @@ import { sliceIntoChunks } from "./utils/util.js";
 
 export const DEFAULT_MODEL = "Xenova/clip-vit-base-patch32";
 
+// The embedder always produces dense values, but v8's `PineconeRecord` types
+// `values` as optional (a record may carry only sparseValues). Narrow it here
+// so callers can pass `.values` straight into query/upsert without guards.
+export type DenseRecord = PineconeRecord & { values: number[] };
+
 class Embedder {
 
   private processor: Processor;
@@ -37,7 +42,7 @@ class Embedder {
   }
 
   // Embeds an image and returns the embedding
-  async embed(imagePath: string, metadata?: RecordMetadata): Promise<PineconeRecord> {
+  async embed(imagePath: string, metadata?: RecordMetadata): Promise<DenseRecord> {
     try {
       // Ensure the model is loaded before embedding.
       await this.ready();

--- a/server/indexImages.ts
+++ b/server/indexImages.ts
@@ -1,10 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable dot-notation */
 import * as dotenv from "dotenv";
-import {
-  Pinecone,
-  type ServerlessSpecCloudEnum,
-} from "@pinecone-database/pinecone";
+import { Pinecone } from "@pinecone-database/pinecone";
 import { embedder } from "./embeddings.ts";
 import { getEnv, listFiles } from "./utils/util.ts";
 import { embedAndUpsert } from "./utils/embedAndUpsert.js";
@@ -14,7 +11,7 @@ dotenv.config();
 // Index setup
 const indexImages = async () => {
   const indexName = getEnv("PINECONE_INDEX");
-  const indexCloud = getEnv("PINECONE_CLOUD") as ServerlessSpecCloudEnum;
+  const indexCloud = getEnv("PINECONE_CLOUD");
   const indexRegion = getEnv("PINECONE_REGION");
   const pinecone = new Pinecone();
 

--- a/server/utils/chunkedUpsert.ts
+++ b/server/utils/chunkedUpsert.ts
@@ -19,7 +19,7 @@ export const chunkedUpsert = async (
     await Promise.allSettled(
       chunks.map(async (chunk) => {
         try {
-          await index.namespace(namespace).upsert(chunk);
+          await index.namespace(namespace).upsert({ records: chunk });
         } catch (e) {
           console.log("Error upserting chunk", e);
         }

--- a/tests/server/pinecone.e2e.test.ts
+++ b/tests/server/pinecone.e2e.test.ts
@@ -105,6 +105,10 @@ describe.skipIf(!HAS_KEY)("Pinecone live end-to-end", () => {
     const target = fixtures[0];
     const query = await embedder.embed(target);
 
+    // Serverless indexes are eventually consistent: recordCount in
+    // describeIndexStats can tick up before every vector is queryable. Poll
+    // until the query image's own vector is the top match, rather than until
+    // *any* match exists, so a freshness lag doesn't surface a different image.
     const result = await waitFor(
       () =>
         index.namespace(NAMESPACE).query({
@@ -112,7 +116,7 @@ describe.skipIf(!HAS_KEY)("Pinecone live end-to-end", () => {
           topK: 3,
           includeMetadata: true,
         }),
-      (r) => (r.matches?.length ?? 0) > 0
+      (r) => r.matches?.[0]?.id === query.id
     );
 
     expect(result.matches && result.matches.length).toBeGreaterThan(0);

--- a/tests/server/pinecone.e2e.test.ts
+++ b/tests/server/pinecone.e2e.test.ts
@@ -1,10 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import path from "path";
 import { fileURLToPath } from "url";
-import {
-  Pinecone,
-  type ServerlessSpecCloudEnum,
-} from "@pinecone-database/pinecone";
+import { Pinecone } from "@pinecone-database/pinecone";
 
 import { embedder } from "../../server/embeddings.ts";
 
@@ -28,7 +25,7 @@ const fixture = (name: string) =>
   path.join(__dirname, "..", "fixtures", "images", name);
 
 const NAMESPACE = "default";
-const CLOUD = (process.env.PINECONE_CLOUD || "aws") as ServerlessSpecCloudEnum;
+const CLOUD = process.env.PINECONE_CLOUD || "aws";
 const REGION = process.env.PINECONE_REGION || "us-east-1";
 
 // Unique, valid index name (lowercase alphanumeric + hyphens, <= 45 chars).
@@ -81,7 +78,7 @@ describe.skipIf(!HAS_KEY)("Pinecone live end-to-end", () => {
     const records = await Promise.all(
       fixtures.map((f) => embedder.embed(f, { imagePath: f }))
     );
-    await index.namespace(NAMESPACE).upsert(records);
+    await index.namespace(NAMESPACE).upsert({ records });
 
     // Wait until all upserted vectors are visible.
     await waitFor(
@@ -130,7 +127,7 @@ describe.skipIf(!HAS_KEY)("Pinecone live end-to-end", () => {
     const target = fixtures[1];
     const { id } = await embedder.embed(target);
 
-    await index.namespace(NAMESPACE).deleteOne(id);
+    await index.namespace(NAMESPACE).deleteOne({ id });
 
     const stats = await waitFor(
       () => index.namespace(NAMESPACE).describeIndexStats(),

--- a/tests/server/pinecone.mocked.test.ts
+++ b/tests/server/pinecone.mocked.test.ts
@@ -104,7 +104,7 @@ describe("deleteImage", () => {
       })
     );
     // ...deletes that vector...
-    expect(deleteOneMock).toHaveBeenCalledWith("vec-123");
+    expect(deleteOneMock).toHaveBeenCalledWith({ id: "vec-123" });
     // ...and marks the file deleted on disk.
     expect(fs.rename).toHaveBeenCalledWith("data/a.jpg", "data/a.jpg_deleted");
   });


### PR DESCRIPTION
## Summary
Bumps `@pinecone-database/pinecone` across six majors (**2.2.2 → 8.0.0**). The only breaking changes in the [v8 migration guide](https://github.com/pinecone-io/pinecone-ts-client/blob/main/guides/upgrading/v8-migration.md) are to the Assistant API, which this app doesn't use — so the code delta is limited to data-plane argument-shape changes and one removed type.

## Changes

**Dependency**
- `@pinecone-database/pinecone` `^2.0.0` → `^8.0.0`
- TypeScript floor `^5.0.2` → `^5.2.0`; added `engines.node: ">=20"` (v8 requires Node ≥ 20 / TS ≥ 5.2)

**Source (v8 API adjustments)**
- `chunkedUpsert.ts` — `.upsert(chunk)` → `.upsert({ records: chunk })`
- `deleteImage.ts` — `.deleteOne(id)` → `.deleteOne({ id })`, plus a guard for the not-found case (v8 requires a non-empty `id`)
- `indexImages.ts` — dropped the removed `ServerlessSpecCloudEnum` type (`cloud` is now `string`)
- `embeddings.ts` — added a `DenseRecord` return type so `embed().values` stays a defined `number[]` (v8 made `PineconeRecord.values` optional)

**Tests**
- `pinecone.e2e.test.ts` — same `ServerlessSpecCloudEnum` / `upsert` / `deleteOne` fixes
- `pinecone.mocked.test.ts` — `deleteOne` assertion → `{ id: "vec-123" }`

## Compatibility notes
`new Pinecone()`, `pinecone.index(name)` (string overload), `.namespace()` chaining, `query()`, `createIndex()`, and `listIndexes()` all remain compatible in v8 — no changes needed.

## Verification
- `npm run typecheck` — clean
- `npm run lint` — only a pre-existing warning in `app/src/main.tsx` (untouched)
- `npm run test:app` — 5/5
- `npm run test:server` — **40/40, including the live Pinecone e2e** against a real serverless index (create → upsert → query → deleteOne → deleteIndex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)