### PR TITLE
Default PINECONE_CLOUD and PINECONE_REGION when unset

### DIFF
--- a/server/indexImages.ts
+++ b/server/indexImages.ts
@@ -3,7 +3,12 @@
 import * as dotenv from "dotenv";
 import { Pinecone } from "@pinecone-database/pinecone";
 import { embedder } from "./embeddings.ts";
-import { getEnv, listFiles } from "./utils/util.ts";
+import {
+  getEnv,
+  listFiles,
+  DEFAULT_PINECONE_CLOUD,
+  DEFAULT_PINECONE_REGION,
+} from "./utils/util.ts";
 import { embedAndUpsert } from "./utils/embedAndUpsert.js";
 
 dotenv.config();
@@ -11,8 +16,8 @@ dotenv.config();
 // Index setup
 const indexImages = async () => {
   const indexName = getEnv("PINECONE_INDEX");
-  const indexCloud = getEnv("PINECONE_CLOUD");
-  const indexRegion = getEnv("PINECONE_REGION");
+  const indexCloud = getEnv("PINECONE_CLOUD", DEFAULT_PINECONE_CLOUD);
+  const indexRegion = getEnv("PINECONE_REGION", DEFAULT_PINECONE_REGION);
   const pinecone = new Pinecone();
 
   try {

--- a/server/utils/util.ts
+++ b/server/utils/util.ts
@@ -26,19 +26,30 @@ async function listFiles(dir: string): Promise<string[]> {
   return filePaths;
 }
 
-export const getEnv = (key: string): string => {
+// Sensible defaults for where the serverless index is deployed, so the app
+// doesn't refuse to start over an unset region. These match the free-tier
+// serverless combination and the values documented in the README.
+export const DEFAULT_PINECONE_CLOUD = "aws";
+export const DEFAULT_PINECONE_REGION = "us-east-1";
+
+// Reads an environment variable. When a `defaultValue` is supplied, a missing
+// or empty variable falls back to it instead of throwing; otherwise the
+// variable is required and its absence is a hard error.
+export const getEnv = (key: string, defaultValue?: string): string => {
   const value = process.env[key];
   if (!value) {
+    if (defaultValue !== undefined) {
+      return defaultValue;
+    }
     throw new Error(`${key} environment variable not set`);
   }
   return value;
 };
 
 const validateEnvironmentVariables = () => {
+  // Only these are truly required; cloud and region default (see above).
   getEnv("PINECONE_API_KEY");
   getEnv("PINECONE_INDEX");
-  getEnv("PINECONE_CLOUD");
-  getEnv("PINECONE_REGION");
 };
 
 export { listFiles, sliceIntoChunks, validateEnvironmentVariables };

--- a/tests/server/util.test.ts
+++ b/tests/server/util.test.ts
@@ -45,6 +45,23 @@ describe("getEnv", () => {
     expect(() => getEnv("__TEST_EMPTY_ENV__")).toThrow();
     delete process.env.__TEST_EMPTY_ENV__;
   });
+
+  it("returns the default when the variable is missing", () => {
+    delete process.env.__TEST_DEFAULT_ENV__;
+    expect(getEnv("__TEST_DEFAULT_ENV__", "fallback")).toBe("fallback");
+  });
+
+  it("returns the default when the variable is an empty string", () => {
+    process.env.__TEST_DEFAULT_ENV__ = "";
+    expect(getEnv("__TEST_DEFAULT_ENV__", "fallback")).toBe("fallback");
+    delete process.env.__TEST_DEFAULT_ENV__;
+  });
+
+  it("prefers the set value over the default", () => {
+    process.env.__TEST_DEFAULT_ENV__ = "real";
+    expect(getEnv("__TEST_DEFAULT_ENV__", "fallback")).toBe("real");
+    delete process.env.__TEST_DEFAULT_ENV__;
+  });
 });
 
 describe("listFiles", () => {


### PR DESCRIPTION
## Summary
The app refused to start indexing if `PINECONE_CLOUD` or `PINECONE_REGION` were missing from the environment — a poor failure mode, since the demo effectively uses one serverless cloud/region combination. This makes those two variables optional with sensible defaults.

## Changes
- `getEnv(key, defaultValue?)` — now accepts an optional default; a missing/empty var falls back to it instead of throwing.
- `indexImages.ts` — `PINECONE_CLOUD` / `PINECONE_REGION` default to `aws` / `us-east-1` (the values documented in the README) via new `DEFAULT_PINECONE_CLOUD` / `DEFAULT_PINECONE_REGION` constants.
- `validateEnvironmentVariables()` — now only requires `PINECONE_API_KEY` and `PINECONE_INDEX` (cloud/region default).
- Tests for the new `getEnv` default behavior (missing → default, empty → default, set value wins).

## Verification
Verified end-to-end: with `PINECONE_CLOUD`/`PINECONE_REGION` unset, the app boots and `GET /indexImages` completes (previously it errored instantly). `getEnv` unit tests pass (12/12). Behavior is unchanged when the vars are set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)