### PR TITLE
Preserve result image aspect ratio instead of cropping

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -203,7 +203,7 @@ function App() {
             <img
               src={result.src}
               alt="Search result"
-              className="w-full h-4/5 object-cover"
+              className="w-full h-4/5 object-contain"
             />
             <p className="w-full text-center bg-blue-500 text-white">
               Score: {result.score}


### PR DESCRIPTION
## Summary
The search-results grid rendered each image with `object-cover`, which fills the fixed-size card by **cropping** — and visibly stretches/crops differently as the card's aspect ratio changes on window resize. This switches to `object-contain` so each result scales to fit its card with aspect ratio preserved.

## Change
`app/src/App.tsx` — result `<img>` class `object-cover` → `object-contain`. Images now letterbox against the card's existing `bg-gray-600` background (the same way the selectable thumbnails above already render) instead of being cropped.

## Tradeoff
"No cropping" means letterboxing: wide (16:9) screenshots now show gray padding in the leftover card space rather than filling it edge-to-edge. This is the intended behavior — preserve the full image over filling the frame.

## Verification
React component tests pass (5/5). Verified live in the running dev app: result images retain aspect ratio with no cropping as the browser is resized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)