### PR TITLE
docs: clarify free-plan region and Index-button behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ PINECONE_REGION="us-east-1"
 
 `PINECONE_INDEX` is the name of the index where this demo will store and query embeddings. You can change `PINECONE_INDEX` to any name you like, but make sure the name not going to collide with any indexes you are already using.
 
-`PINECONE_CLOUD` and `PINECONE_REGION` define where the index should be deployed. Currently, this is the only available cloud and region combination (`aws` and `us-west-2`), so it's recommended to leave them defaulted.
+`PINECONE_CLOUD` and `PINECONE_REGION` define where the serverless index is deployed. Both are optional — if you leave them out of your `.env`, the app defaults to `aws` and `us-east-1`.
+
+If you're on Pinecone's free (Starter) plan, `aws`/`us-east-1` is the only cloud and region you can create an index in, so the defaults work out of the box with no changes. Setting them to any other region will cause index creation to fail with an error asking you to upgrade your plan. Deploying elsewhere requires a paid plan.
 
 ## Dependencies
 
@@ -253,20 +255,20 @@ To delete an image, we call the `/deleteImage` endpoint with the image path. We 
 
 ## Running the application
 
-In order to run the aaplication:
+In order to run the application:
 
-1. If you havn't already, clone this repository. 
+1. If you haven't already, clone this repository. 
 2. Then run:
 
 ```bash
 npm run dev
 ```
 
-You should recieve a message: "Server started at http://localhost:3000". Copy this url into your web browser.
+You should receive a message: "Server started at http://localhost:3000". Copy this url into your web browser.
 
-3. Click the green "Index" button in the top left of the screen. Wait for the app to finish loading. 
+3. Click the green "Index" button in the top left of the screen. This embeds the sample images and upserts them into Pinecone, so it can take a moment — watch the terminal running `npm run dev`, where you'll see the index being created and vectors being upserted. Wait for the app to finish loading before continuing. 
 4. Select an image. 
-5. You will now be shown all similar image found within the dataset. 
+5. You will now be shown all similar images found within the dataset. 
 
 And here's the final result:
 


### PR DESCRIPTION
## Summary

Addresses the two remaining open README issues (#8 and #5).

### #8 — region confusion
The README claimed the only supported cloud/region was **`aws`/`us-west-2`** and told users to "leave them defaulted." That was wrong on two counts:
- `us-west-2` is actually **rejected** on the free plan.
- The `.env` example directly above it uses `us-east-1`.

I verified the real rule against the backend (`pinecone-db`): free/Starter-plan serverless index creation is a **hard restriction to `aws`/`us-east-1`** — `V4_FREE_TIER_AWS_ENV_NAMES` maps to `("aws","us-east-1")`, and `assign_serverless_env` returns a `BadRequest` ("upgrade your plan") for any other region. This also matches the app's own default (`DEFAULT_PINECONE_CLOUD`/`DEFAULT_PINECONE_REGION`).

The section now states that both env vars are optional, default to `aws`/`us-east-1`, work out of the box on the free plan, and that other regions require a paid plan.

### #5 — usability additions
The issue asked for two README notes:
1. That `npm run dev` is how you start the project — already documented, left intact.
2. That you press the green **Index** button and can check the console to confirm the index was created and vectors upserted — **added**: step 3 now explains what the button does and points users to the `npm run dev` terminal to watch index creation / upsert progress.

Also fixed several typos in that section (`aaplication`, `havn't`, `recieve`, `similar image`).

## Notes
Docs-only change; no code touched.

Closes #8
Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)