### PR TITLE
chore: drop unused deps, unpin proxy from beta, tidy package metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,10 @@
         "@huggingface/transformers": "^4.2.0",
         "@pinecone-database/pinecone": "^8.0.0",
         "@radix-ui/react-alert-dialog": "^1.0.5",
-        "console-table-printer": "^2.11.1",
-        "cross-fetch": "^3.1.6",
         "dotenv": "^16.1.3",
         "express": "^4.18.2",
         "express-rate-limit": "^8.5.2",
-        "http-proxy-middleware": "^3.0.0-beta.1",
+        "http-proxy-middleware": "^3.0.7",
         "multer": "^2.2.0",
         "nodemon": "^3.0.1",
         "onnxruntime-node": "^1.15.0",
@@ -4170,15 +4168,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/console-table-printer": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.16.1.tgz",
-      "integrity": "sha512-Sc9FRJ4O9xKGNrvulNdPfK5SyBcZ6lcaRnDE4AQ/uw6IDtjHhsqyzzqcnMikjyGaiOOF2tNOKoBhbVjRvFy9Lw==",
-      "license": "MIT",
-      "dependencies": {
-        "simple-wcswidth": "^1.1.2"
-      }
-    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -4221,15 +4210,6 @@
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cross-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
-      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4621,17 +4601,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/entities": {
@@ -6208,7 +6177,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -7536,48 +7505,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-releases": {
@@ -9340,12 +9267,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/simple-wcswidth": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
-      "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
-      "license": "MIT"
     },
     "node_modules/slash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pinecone-image-search-example",
   "version": "1.0.0",
-  "description": "",
+  "description": "An example image search engine built with Pinecone and the CLIP model.",
   "type": "module",
   "scripts": {
     "dev:server": "nodemon --watch 'server/**/*.ts' --exec 'tsx' server/index.ts",
@@ -16,11 +16,11 @@
     "test:app": "vitest run --project app"
   },
   "keywords": [
-    "starter",
-    "template",
+    "pinecone",
+    "vector-search",
+    "clip",
     "node",
     "typescript",
-    "llm",
     "image search"
   ],
   "author": "Roie Schwaber-Cohen",
@@ -32,12 +32,10 @@
     "@huggingface/transformers": "^4.2.0",
     "@pinecone-database/pinecone": "^8.0.0",
     "@radix-ui/react-alert-dialog": "^1.0.5",
-    "console-table-printer": "^2.11.1",
-    "cross-fetch": "^3.1.6",
     "dotenv": "^16.1.3",
     "express": "^4.18.2",
     "express-rate-limit": "^8.5.2",
-    "http-proxy-middleware": "^3.0.0-beta.1",
+    "http-proxy-middleware": "^3.0.7",
     "multer": "^2.2.0",
     "nodemon": "^3.0.1",
     "onnxruntime-node": "^1.15.0",


### PR DESCRIPTION
## Why

Maintenance hygiene on `package.json` — no runtime behavior change.

## What changed

- **Removed two unused dependencies.** `cross-fetch` and `console-table-printer` are declared in `dependencies` but referenced nowhere in `server/`, `app/`, or `tests/` (leftover scaffold cruft). Removing them also prunes their transitive deps (`node-fetch`, `encoding`, `whatwg-url`, `tr46`, `webidl-conversions`, `simple-wcswidth`) from the lockfile.
- **Unpinned `http-proxy-middleware` from a beta.** The specifier was `^3.0.0-beta.1`, which advertised a dependency on a pre-release even though it resolved to stable `3.0.7`. Changed to `^3.0.7`; the resolved version is unchanged, so there's no lockfile churn there.
- **Tidied metadata.** Filled in the empty `description` and replaced the leftover `starter`/`template` scaffold keywords with ones that actually describe this project.

## Testing

- `npm run lint` — passes (one pre-existing, unrelated warning in `main.tsx`)
- `npm run typecheck` — passes
- `npm run build:app` — passes
- `npm test` — all 50 tests pass, including the live Pinecone e2e (`createIndex`/`upsert`/`query`/`deleteOne` against a real throwaway index)
- `npm audit --omit=dev` — 0 vulnerabilities

> Note: `npm audit` (incl. dev) surfaces one low-severity, Windows-only esbuild advisory via Vite. It is **pre-existing** (not in this diff's lockfile changes) and dev-only; left out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)