### PR TITLE
security: remediate open Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3860,9 +3860,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6308,9 +6308,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -6806,9 +6806,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -7457,9 +7457,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -7590,15 +7590,15 @@
       }
     },
     "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/nodemon/node_modules/has-flag": {
@@ -8077,9 +8077,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -8097,7 +8097,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary

Resolves all **11 open Dependabot alerts** (8 high, 3 medium) on this repo. Every alert is a **transitive** dependency, fixed with `npm audit fix` (no `--force`). The only changed file is `package-lock.json`.

`npm audit` now reports **0 vulnerabilities** (down from 5 high after dedup).

## Packages fixed

| Package | Scope | From → To | Severity | Advisory |
|---|---|---|---|---|
| brace-expansion | dev + runtime | 1.1.16 → 1.1.18, 5.0.7 → 5.0.9 | high | DoS via unbounded expansion (GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895) — alerts #230, #234, #236 |
| ip-address | runtime | 10.2.0 → 10.5.0 | high/med | SSRF & trust-boundary bypass (GHSA-mwp4-54f8-5fhr, GHSA-4xrf-jv44-h6hh, GHSA-22jq-vg5j-6vgg) — alerts #232, #233, #235 |
| js-yaml | dev | 4.3.0 → 4.3.1 | high | Quadratic CPU in `!!omap` resolution (GHSA-5p4m-2wfm-xmqj) — alert #237 |
| nanoid | dev | 3.3.15 → 3.3.18 | high | Infinite loop on negative/zero size (GHSA-28wg-ghj8-5hjv, GHSA-2v37-7h3g-55p8) — alerts #238, #239 |
| postcss | dev | 8.5.16 → 8.5.26 | high/med | Path traversal in source-map auto-loading (GHSA-r28c-9q8g-f849, GHSA-fxqj-rqcc-2cmp) — alerts #231, #240 |

## Deferred

None. All open alerts are remediated.

## CI

No CI changes. The repo already has `.github/workflows/test.yml` (install + lint + typecheck + test + frontend build), which is sufficient.

## Local verification

All commands run on this branch before pushing:

| Check | Command | Result |
|---|---|---|
| Audit | `npm audit` | **0 vulnerabilities** |
| Lint | `npm run lint` | pass (1 pre-existing unrelated warning) |
| Typecheck | `npm run typecheck` | pass |
| Test | `npm test` | pass — 47 passed, 3 e2e skipped (no API key) |
| Build | `npm run build:app` | pass — Vite build succeeded |

## Note on existing Dependabot PRs

The 5 open Dependabot PRs (#31–#35) each bump one of these packages individually. This PR consolidates all of them (and covers the additional transitive ranges they miss) in a single lockfile change. Those PRs are left untouched for the maintainer to close.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only patch upgrades with no app code or CI changes; typical low-risk dependency hygiene.
> 
> **Overview**
> **Resolves 11 open Dependabot alerts** by updating only `package-lock.json` with `npm audit fix` (no `--force`). No application source changes.
> 
> Transitive packages are bumped to patched versions: **brace-expansion** (1.1.18 / 5.0.9), **ip-address** (10.5.0), **js-yaml** (4.3.1), **nanoid** (3.3.18), and **postcss** (8.5.26), addressing DoS, SSRF/trust-boundary, YAML parsing, nanoid loop, and postcss source-map issues. **`npm audit` is expected to report 0 vulnerabilities** after this change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6c9abec5ac16d3a233b3c48264252512d2b4859. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->