### PR TITLE
ci: add dependency audit + Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      production-dependencies:
+        dependency-type: production
+        update-types:
+          - patch
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Test
         run: npm test
 
+      - name: Dependency audit (fail on high or critical)
+        run: npm audit --audit-level=high
+
       # Real Vite production build of the frontend. Catches bundling/plugin
       # breaks (e.g. a Vite major bump) that `tsc --noEmit` alone won't surface.
       - name: Build frontend


### PR DESCRIPTION
## What

Brings `image-search-example` to the standard CI quality bar. The existing CI is already strong (lint, typecheck, unit + CLIP integration + mocked Pinecone + Express + React tests, real Vite build, fork-safe e2e gating, least-privilege permissions). This adds the two missing pieces:

1. **Dependency audit on PRs** — `npm audit --audit-level=high` in the credential-free test job, so PRs fail on high/critical vulnerabilities.
2. **`.github/dependabot.yml`** — weekly `npm` + `github-actions` updates (grouped).

## Verification (local, npm 10 — matches CI's Node 22)

- `npm audit --audit-level=high` → **0 vulnerabilities** ✅ — no dependency changes needed; CI is green under the new gate.

## Note

No `prettier`/format script is configured in this repo, so I left a format-check out of scope. If you'd like one, that's a small follow-up (add prettier + `format:check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only GitHub workflow and Dependabot configuration; no runtime or application code changes.
> 
> **Overview**
> **CI now fails PRs on high or critical npm vulnerabilities** by running `npm audit --audit-level=high` in the credential-free `test` job (after unit tests, before the frontend build).
> 
> **Dependabot** is configured via `.github/dependabot.yml` for weekly **npm** updates (grouped dev minor/patch vs production patch only, up to 10 open PRs) and **GitHub Actions** updates (weekly, up to 5 open PRs). Dependabot PRs already hit the same `pull_request` workflow, so bumps are validated by the existing test suite plus the new audit step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8e612c84f871f82a7ecc68965f38e3c3c062907. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->