### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS
+# Auto-requests review from the owners below on every pull request.
+# Docs: https://docs.github.com/articles/about-code-owners
+
+* @pinecone-io/dev-advocates


### PR DESCRIPTION
Adds `.github/CODEOWNERS` so pull requests automatically request review from the appropriate owners.

Owners: `@pinecone-io/dev-advocates`

Part of an org-wide rollout to ensure every public repo has code owners configured.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> GitHub-only workflow metadata with no impact on application code or deployments.
> 
> **Overview**
> Adds a new **`.github/CODEOWNERS`** file so GitHub **auto-requests review** from **`@pinecone-io/dev-advocates`** on every pull request via the `*` path rule.
> 
> This is part of an org-wide rollout to ensure public repos have code owners configured; it does not change application code or runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22c255245393db9ab14b882c7c805fb16eb84c2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->